### PR TITLE
Fix 'screenshots' script Crash due to GDI Object Buildup - resolves #2

### DIFF
--- a/miscellaneous/screenshot.ahk
+++ b/miscellaneous/screenshot.ahk
@@ -68,7 +68,6 @@ captureArea:
     gui +AlwaysOnTop +Border +LastFound +ToolWindow -caption
     WinSet, Transparent, 30
 
-    pToken := Gdip_Startup()
     MouseGetPos, mouseX0, mouseY0
     SetTimer, overlay, 1
 


### PR DESCRIPTION
The `screenshots` script was terminating unexpectedly after running for several hours. Upon investigation I found a gradual increase in memory usage with each execution. In a further analysis I detected that this was due to an accumulation of GDI objects (as indicated by the Task Manager)

I traced this back to a redundant initialization of GDI+ in the `captureArea` function. This initialization was unnecessary because GDI+ setup and teardown was already being handled in the `saveScreenshot` function.

With the removal of the duplicated GDI+ initialization, the script now runs with improved stability over extended use. I've monitored the script for a week with no signs of GDI object buildup, and it has remained stable throughout this period.

Closes #2
